### PR TITLE
Trying to fix city and subdivision for CH

### DIFF
--- a/resources/address_format/CH.json
+++ b/resources/address_format/CH.json
@@ -5,9 +5,13 @@
 		"recipient",
 		"addressLine1",
 		"locality",
+		"administrativeArea",
 		"postalCode"
 	],
-	"uppercase_fields": [],
+	"uppercase_fields": [
+        	"administrativeArea"
+	],
+    	"administrative_area_type": "state",
 	"locality_type": "city",
 	"postal_code_type": "postal",
 	"postal_code_pattern": "\\d{4}",


### PR DESCRIPTION
As reported on d.o I tried to fix the city and subdivision form items. I tried to sue the same structure as US uses for administrative_area. This is not working yet. What am I doing wrong?

Here is the issue on d.o: https://www.drupal.org/node/2581257
